### PR TITLE
Fix deprecated hosted runner OS

### DIFF
--- a/.github/prepare.py
+++ b/.github/prepare.py
@@ -19,19 +19,19 @@ set_output('vtag', vtag)
 
 configurations = []
 for bsh_host_arch, bsh_host_platform, bsh_host_libc, bsh_static_dynamic, bsh_build_platform,        runs_on in [
-	(   'x86_64' ,           'linux',         'gnu',           'static',            'linux', 'ubuntu-18.04' ),
+	(   'x86_64' ,           'linux',         'gnu',           'static',            'linux', 'ubuntu-20.04' ),
 	(   'x86_64' ,         'windows',       'mingw',           'static',          'windows', 'windows-2019' ),
 	(   'x86_64' ,         'windows',       'mingw',          'dynamic',          'windows', 'windows-2019' ),
 	(   'x86_64' ,         'windows',        'msvc',           'static',          'windows', 'windows-2019' ),
 	(   'x86_64' ,         'windows',        'msvc',          'dynamic',          'windows', 'windows-2019' ),
 	(      'x86' ,         'windows',        'msvc',           'static',          'windows', 'windows-2019' ),
 	(      'x86' ,         'windows',        'msvc',          'dynamic',          'windows', 'windows-2019' ),
-	(   'x86_64' ,          'darwin',       'macos',           'static',           'darwin',   'macos-11.0' ),
-	(  'aarch64' ,          'darwin',       'macos',           'static',           'darwin',   'macos-11.0' ),
-	(      'x86' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-18.04' ),
-	(   'x86_64' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-18.04' ),
-	(      'arm' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-18.04' ),
-	(  'aarch64' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-18.04' ),
+	(   'x86_64' ,          'darwin',       'macos',           'static',           'darwin',     'macos-11' ),
+	(  'aarch64' ,          'darwin',       'macos',           'static',           'darwin',     'macos-11' ),
+	(      'x86' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-20.04' ),
+	(   'x86_64' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-20.04' ),
+	(      'arm' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-20.04' ),
+	(  'aarch64' ,         'android',      'bionic',           'static',            'linux', 'ubuntu-20.04' ),
 ]:
 	for debug_release in [ 'debug', 'release' ]:
 		configurations.append({

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - id: prepare
         run: python ./.github/prepare.py
         env:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: python -m pip install meson ninja
       - if: matrix.bsh_build_platform == 'darwin'
         run: brew install coreutils bash


### PR DESCRIPTION
[Host runner 'Ubuntu 18.04' is deprecated and fully unsupported in by 2023/04/01](https://github.com/actions/runner-images/issues/6002). I guess you would know this, but the reason that I requested this is I just found the Actions in the Korean mod doesn't work because it's brownout period. To prevent this from happening again, I'm pull-requesting this for now. Please merge this when if you think this is ok.